### PR TITLE
Make it so that you don't have to manually create fully-qualified models...

### DIFF
--- a/backbone-faux-server.js
+++ b/backbone-faux-server.js
@@ -257,7 +257,7 @@
         //  callbacks. (The relevant 'success' or 'error' event will be triggered by backbone)
         execHandler = function () {
             var result = c.route.handler.apply(null, [c].concat(c.route.handlerParams)); // Handle
-            deferred[_.isString(result) ? "reject" : "resolve"](result);
+            deferred[_.isString(result) ? "reject" : "resolve"](model, result, options);
         };
 
         model.trigger("request", model, null, options);


### PR DESCRIPTION
... in the result handler.  Instead, the result handler can return pure JSON and Backbone & Backbone.Relational will handle turning the result into Backbone Model instances.  This also helps for cases where you're just using the Backbone Model to make the request and you're doing something unusual with the result in your model's success handler.  Specifically, if the server returns an array in response to a GET call, we want faux-server to return that same array, and we want to do something with it in our success handler - but with faux-server calling resolve(result), we got a Backbone error that parse() was undefined.
