### PR TITLE
Adding abort method

### DIFF
--- a/backbone-faux-server.js
+++ b/backbone-faux-server.js
@@ -263,7 +263,7 @@
         //  callbacks. (The relevant 'success' or 'error' event will be triggered by backbone)
         execHandler = function () {
             var result = c.route.handler.apply(null, [c].concat(c.route.handlerParams)); // Handle
-            deferred[_.isString(result) ? "reject" : "resolve"](model, result, options);
+            deferred[_.isString(result) ? "reject" : "resolve"](result);
         };
 
         model.trigger("request", model, null, options);


### PR DESCRIPTION
Added "abort" method, and made it so that faux-server returns the real deferred instead of a read-only promise. This is so that you can do things like:

var request = myModel.save();
request.abort();

"abort" is supported by XMLHttpRequest, so it should work no matter what ajax library you use with Backbone.  
