### PR TITLE
Defines default Backbone.sync options parameter

### DIFF
--- a/backbone-faux-server.js
+++ b/backbone-faux-server.js
@@ -231,7 +231,10 @@
         // If faux-server is disabled, fall back to original sync
         if (!isEnabled) { return nativeSync.call(model, crudMethod, model, options); }
         
-        options = options || {};
+        _.defaults(options || (options = {}), {
+            emulateHTTP: Backbone.emulateHTTP,
+            emulateJSON: Backbone.emulateJSON
+        });
 
         var
             // Sync context


### PR DESCRIPTION
The mocked behavior is inconsistent with Backbone's actual behavior.  Backbone.sync's `options` parameter defaults to an empty object when the caller does not supply it: https://github.com/jashkenas/backbone/blob/master/backbone.js#L1134
